### PR TITLE
Refactors confirm implementation to perform dom insertion seperately

### DIFF
--- a/bootstrap-prompts-alert.js
+++ b/bootstrap-prompts-alert.js
@@ -1,14 +1,14 @@
 window._originalAlert = window.alert;
 window.alert = function(text) {
-  bootStrapAlert = function() {
-    if(! $.fn.modal.Constructor)
-      return false;
-    if($('#windowAlertModal').length == 1)
-      return true;
-    $('body').append(' \
+    var bootStrapAlert = function() {
+        if(! $.fn.modal.Constructor)
+            return false;
+        if($('#windowAlertModal').length == 1)
+            return true;
+        $('body').append(' \
     <div id="windowAlertModal" class="modal hide fade" tabindex="-1" role="dialog" aria-hidden="true"> \
       <div class="modal-body"> \
-      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button> \
+      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button> \
         <p> alert text </p> \
       </div> \
       <div class="modal-footer"> \
@@ -16,50 +16,58 @@ window.alert = function(text) {
       </div> \
     </div> \
     ');
-    return true;
-  }
-  if ( bootStrapAlert() ){
-    $('#windowAlertModal .modal-body p').text(text);
-    $('#windowAlertModal').modal();
-  }  else {
-    console.log('bootstrap was not found');
-    window._originalAlert(text);
-  }
+        return true;
+    }
+    if ( bootStrapAlert() ){
+        $('#windowAlertModal .modal-body p').text(text);
+        $('#windowAlertModal').modal();
+    }  else {
+        console.log('bootstrap was not found');
+        window._originalAlert(text);
+    }
 }
 window._originalConfirm = window.confirm;
 window.confirm = function(text, cb) {
-  bootStrapConfirm = function() {
-    if(! $.fn.modal.Constructor)
-      return false;
-    if($('#windowConfirmModal').length == 1)
-      return true;
-    $('body').append(' \
-    <div id="windowConfirmModal" class="modal hide fade" tabindex="-1" role="dialog" aria-hidden="true"> \
-      <div class="modal-body"> \
-      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button> \
-        <p> alert text </p> \
-      </div> \
-      <div class="modal-footer"> \
-        <button class="btn btn-danger" data-dismiss="modal" aria-hidden="true">Close</button> \
-        <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">Ok</button> \
-      </div> \
-    </div> \
-    ');
-    function unbind() { 
-      $("#windowConfirmModal .btn-primary").unbind('click', confirm);
-      $("#windowConfirmModal .btn-danger").unbind('click', deny);
+    var initTemplate = function(){
+      if($('#windowConfirmModal').length == 1)
+        return true;
+      $('body').append(' \
+        <div id="windowConfirmModal" class="modal hide fade" tabindex="-1" role="dialog" aria-hidden="true"> \
+          <div class="modal-body"> \
+          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button> \
+            <p> alert text </p> \
+          </div> \
+          <div class="modal-footer"> \
+            <button class="btn btn-danger" data-dismiss="modal" aria-hidden="true">Close</button> \
+            <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">Ok</button> \
+          </div> \
+        </div> \
+      ');
     }
-    function confirm() { cb(true); }
-    function deny() { cb(false); }
-    $("#windowConfirmModal .btn-primary").bind('click', confirm);
-    $("#windowConfirmModal .btn-danger").bind('click', deny);
-    return true;
-  }
-  if ( bootStrapConfirm() ){
-    $('#windowConfirmModal .modal-body p').text(text);
-    $('#windowConfirmModal').modal();
-  }  else {
-    console.log('bootstrap was not found');
-    window._originalConfirm(text);
-  }
+
+    var bootStrapConfirm = function() {
+      if(! $.fn.modal.Constructor)
+          return false;
+
+      $('body').off('click', '#windowConfirmModal .btn-primary');
+      $('body').off('click', '#windowConfirmModal .btn-danger');
+
+      function confirm() { cb(true); }
+      function deny() { cb(false); }
+
+      $('body').on('click', '#windowConfirmModal .btn-primary', confirm);
+      $('body').on('click', '#windowConfirmModal .btn-danger', deny);
+
+      return true;
+    }
+
+    initTemplate()
+
+    if ( bootStrapConfirm() ){
+        $('#windowConfirmModal .modal-body p').text(text);
+        $('#windowConfirmModal').modal();
+    }  else {
+        console.log('bootstrap was not found');
+        cb(window._originalConfirm(text));
+    }
 }


### PR DESCRIPTION
The current implementation will not bind or unbind callbacks properly after your first use of the confirm dialog, which means your original callback is both a) stuck in memory and not dereferenced and b) your future callbacks don't actually get called.

I refactored the implementation to perform dom insertion separately, and also converted the binds to ons as per jQuery's 1.9 preferences.
